### PR TITLE
Merge develop to master

### DIFF
--- a/.github/workflows/label-synchronization.yaml
+++ b/.github/workflows/label-synchronization.yaml
@@ -1,0 +1,29 @@
+name: label-synchronization
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - .github/labels.yaml
+      - .github/workflows/label-sync.yaml
+
+permissions:
+  # write permission is required to edit issue labels
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Synchronize labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          dry-run: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-delete: false
+          yaml-file: .github/labels.yaml

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,104 @@
+name: "pr-validation"
+
+on:
+  pull_request:
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-config.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  title-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        with:
+          types: |
+            breaking
+            bug
+            docs
+            documentation
+            enhancement
+            feat
+            feature
+            fix
+            misc
+            security
+          requireScope: false
+          ignoreLabels: |
+            skip-changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Examples for valid PR titles:
+            feat(ui): Add button component.
+            fix: Correct typo.
+            _type(scope): subject._
+
+            Adding a scope is optional
+
+            Details:
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true
+
+  label-checker:
+    needs: autolabeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danielchabr/pr-labels-checker@v3.3
+        id: lint_pr_labels
+        with:
+          hasSome: breaking,bug,documentation,enhancement,feature,fix,misc,security
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_labels.outputs.passed == false)
+        with:
+          header: pr-labels-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            The PR needs to have at least one of the following labels: breaking, bug, documentation, enhancement, feature, fix, misc, security.
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_labels.outputs.passed != false }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-labels-lint-error
+          delete: true

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,29 @@
+name: "release-drafter"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - .github/**
+      - .pre-commit-config.yaml
+      - CHANGELOG.md
+      - CONTRIBUTING.md
+      - LICENSE
+
+permissions:
+  # write permission is required to create a github release
+  contents: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          publish: false
+          prerelease: false
+          config-name: release-drafter-config.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-validation.yaml
+++ b/.github/workflows/terraform-validation.yaml
@@ -1,0 +1,170 @@
+name: "terraform"
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TF_IN_AUTOMATION: 1
+
+jobs:
+  fmt-lint-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Setup Terraform Linters
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          github_token: ${{ github.token }}
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Lint
+        id: lint
+        run: |
+          echo "Checking ."
+          tflint --format compact
+
+          for d in examples/*/; do
+            echo "Checking ${d} ..."
+            tflint --chdir=$d --format compact
+          done
+
+      - name: Terraform Validate
+        id: validate
+        if: ${{ !vars.SKIP_TERRAFORM_VALIDATE }}
+        run: |
+          for d in examples/*/; do
+            echo "Checking ${d} ..."
+            terraform -chdir=$d init
+            terraform -chdir=$d validate -no-color
+          done
+        env:
+          AWS_DEFAULT_REGION: eu-west-1
+
+      - name: Terraform Test
+        id: test
+        if: ${{ !vars.SKIP_TERRAFORM_TESTS }}
+        run: |
+          terraform init
+          terraform test
+
+      - uses: actions/github-script@v6
+        if: github.event_name == 'pull_request' || always()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Lint 📖\`${{ steps.lint.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>`;
+
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@v1.1.0
+        with:
+          args: --sort-by required
+          git-commit-message: "docs(readme): update module usage"
+          git-push: true
+          output-file: README.md
+          output-method: inject
+          working-dir: .
+        continue-on-error: true # added this to prevent a PR from a remote fork failing the workflow
+
+  tfsec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Terraform security scan
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          github_token: ${{ github.token }}
+          soft_fail: false
+          tfsec_args: --concise-output --force-all-dirs
+
+      - name: Terraform pr commenter
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
+        with:
+          github_token: ${{ github.token }}
+          tfsec_args: --concise-output --force-all-dirs
+
+  checkov:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@v12.2577.0
+        with:
+          container_user: 1000
+          directory: "/"
+          download_external_modules: false
+          framework: terraform
+          output_format: sarif
+          quiet: true
+          skip_check: "CKV_GIT_5,CKV_GLB_1,CKV_TF_1"
+          soft_fail: false
+          skip_path: "examples/*"
+
+### SKIP REASON ###
+# Check | Description | Reason
+
+# CKV_GIT_5 | Ensure GitHub pull requests have at least 2 approvals | We strive for at least 1 approval
+# CKV_GLB_1 | Ensure at least two approving reviews are required to merge a GitLab MR | We strive for at least 1 approval
+# CKV_TF_1 | Ensure Terraform module sources use a commit hash | We think this check is too restrictive and that versioning should be preferred over commit hash

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,31 @@
+name: "update-changelog"
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MCAF_GITHUB_TOKEN }}
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: ${{ github.event.repository.default_branch }}
+          commit_message: "docs(changelog): update changelog"
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Terraform lock file
+.terraform.lock.hcl
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
 # terraform-aws-mcaf-audit-lambdas
+
+## Required update on Audit KMS key
+```
+data "aws_iam_policy_document" "kms_allow_secretsmanager" {
+  statement {
+    sid = "Allow Secrets Manager to use the KMS key"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:CreateGrant",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      "arn:aws:kms:eu-west-1:${data.aws_caller_identity.audit.account_id}:key/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+
+      values = [
+        "${data.aws_caller_identity.audit.account_id}"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+
+      values = [
+        "secretsmanager.eu-west-1.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Allow CloudWatch to use the KMS key"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.eu-west-1.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+
+      values = [
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:log-group:/aws/lambda/*"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Allow S3 to use the KMS key"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid = "Allow reading encrypted deploymentCloudWatch to use the KMS key"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:PrincipalArn"
+
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.audit.account_id}:role/AWSControlTowerExecution"
+      ]
+    }
+  }
+}
+```

--- a/buckets.tf
+++ b/buckets.tf
@@ -1,0 +1,113 @@
+module "audit_logs_archive_bucket" {
+  providers         = { aws = aws.audit }
+  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name              = "${var.bucket_base_name}-${local.account_id}"
+  object_lock_mode  = try(var.object_locking.mode, null)
+  object_lock_years = try(var.object_locking.years, null)
+  versioning        = true
+  tags              = {}
+  kms_key_arn       = var.kms_key_arn
+
+  logging = {
+    target_bucket = module.audit_logs_archive_logging_bucket.name
+    target_prefix = "ep-audit-logs/"
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 14
+      }
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 365
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 90
+        storage_class   = "INTELLIGENT_TIERING"
+      }
+
+      transition = {
+        days          = 90
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  ]
+}
+
+module "audit_logs_archive_logging_bucket" {
+  providers         = { aws = aws.audit }
+  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name              = "${var.bucket_base_name}-logging-${local.account_id}"
+  object_lock_mode  = try(var.object_locking.mode, null)
+  object_lock_years = try(var.object_locking.years, null)
+  versioning        = true
+  tags              = {}
+  kms_key_arn       = var.kms_key_arn
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 14
+      }
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 365
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 90
+        storage_class   = "INTELLIGENT_TIERING"
+      }
+
+      transition = {
+        days          = 90
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  ]
+}
+
+module "lambda_deployment_package_bucket" {
+  providers   = { aws = aws.audit }
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name        = "${var.bucket_base_name}-lambda-${local.account_id}"
+  versioning  = true
+  tags        = {}
+  kms_key_arn = var.kms_key_arn
+
+  lifecycle_rule = [
+    {
+      id      = "default"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 7
+      }
+
+      expiration = {
+        expired_object_delete_marker = true
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 7
+      }
+    }
+  ]
+}
+

--- a/buckets.tf
+++ b/buckets.tf
@@ -1,6 +1,8 @@
 module "audit_logs_archive_bucket" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers         = { aws = aws.audit }
-  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  source            = "schubergphilis/mcaf-s3/aws"
+  version           = "0.13.1"
   name              = "${var.bucket_base_name}-${local.account_id}"
   object_lock_mode  = try(var.object_locking.mode, null)
   object_lock_years = try(var.object_locking.years, null)
@@ -44,8 +46,10 @@ module "audit_logs_archive_bucket" {
 }
 
 module "audit_logs_archive_logging_bucket" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers         = { aws = aws.audit }
-  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  source            = "schubergphilis/mcaf-s3/aws"
+  version           = "0.13.1"
   name              = "${var.bucket_base_name}-logging-${local.account_id}"
   object_lock_mode  = try(var.object_locking.mode, null)
   object_lock_years = try(var.object_locking.years, null)
@@ -84,8 +88,10 @@ module "audit_logs_archive_logging_bucket" {
 }
 
 module "lambda_deployment_package_bucket" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers   = { aws = aws.audit }
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  source      = "schubergphilis/mcaf-s3/aws"
+  version     = "0.13.1"
   name        = "${var.bucket_base_name}-lambda-${local.account_id}"
   versioning  = true
   tags        = {}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -33,25 +33,25 @@ resource "aws_cloudwatch_event_target" "terraform_audit_trigger_daily" {
   }
 }
 
-# resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
-#   provider  = aws.audit
-#   arn       = module.okta_audit_logs_lambda.arn
-#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
-#   target_id = "okta_audit_logs_lambda"
-# 
-#   retry_policy {
-#     maximum_retry_attempts       = 3
-#     maximum_event_age_in_seconds = 60
-#   }
-# }
+resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
+  provider  = aws.audit
+  arn       = module.okta_audit_logs_lambda.arn
+  rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+  target_id = "okta_audit_logs_lambda"
+
+  retry_policy {
+    maximum_retry_attempts       = 3
+    maximum_event_age_in_seconds = 60
+  }
+}
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_audit_lambda" {
-  for_each     = local.audit_lambdas
-  provider     = aws.audit
-  statement_id = "Allow${each.value}AuditLambdaExecutionFromCloudWatch"
-  action       = "lambda:InvokeFunction"
-  #function_name = local.audit_lambda_names[each.key]
-  function_name = module.terraform_cloud_audit_logs_lambda.name
-  principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.audit_trigger_daily.arn
+  for_each      = local.audit_lambdas
+  provider      = aws.audit
+  statement_id  = "Allow${each.value}AuditLambdaExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = local.audit_lambda_names[each.key]
+  #function_name = module.terraform_cloud_audit_logs_lambda.name
+  principal  = "events.amazonaws.com"
+  source_arn = aws_cloudwatch_event_rule.audit_trigger_daily.arn
 }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -46,15 +46,15 @@ resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
   }
 }
 
-# # Gitlab
-# resource "aws_cloudwatch_event_target" "gitlab_audit_trigger_daily" {
-#   provider  = aws.audit
-#   arn       = module.gitlab_audit_logs_lambda.arn
-#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
-#   target_id = "gitlab_audit_logs_lambda"
-# 
-#   retry_policy {
-#     maximum_retry_attempts       = 3
-#     maximum_event_age_in_seconds = 60
-#   }
-# }
+# Gitlab
+resource "aws_cloudwatch_event_target" "gitlab_audit_trigger_daily" {
+  provider  = aws.audit
+  arn       = module.gitlab_audit_logs_lambda.arn
+  rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+  target_id = "gitlab_audit_logs_lambda"
+
+  retry_policy {
+    maximum_retry_attempts       = 3
+    maximum_event_age_in_seconds = 60
+  }
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,57 @@
+resource "aws_cloudwatch_event_rule" "audit_trigger_daily" {
+  provider            = aws.audit
+  name                = "audit-trigger-daily"
+  description         = "Triggers audit lambdas daily."
+  schedule_expression = "cron(0 9 ? * * *)"
+}
+
+# resource "aws_cloudwatch_event_target" "gitlab_audit_trigger_daily" {
+#   provider  = aws.audit
+#   arn       = module.gitlab_audit_logs_lambda.arn
+#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+#   target_id = "gitlab_audit_logs_lambda"
+# 
+#   retry_policy {
+#     maximum_retry_attempts       = 3
+#     maximum_event_age_in_seconds = 60
+#   }
+# }
+
+resource "aws_cloudwatch_event_target" "terraform_audit_trigger_daily" {
+  provider  = aws.audit
+  arn       = module.terraform_cloud_audit_logs_lambda.arn
+  rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+  target_id = "terraform_cloud_audit_logs_lambda"
+
+  dead_letter_config {
+    arn = aws_sqs_queue.terraform_audit_log_dlq.arn
+  }
+
+  retry_policy {
+    maximum_retry_attempts       = 3
+    maximum_event_age_in_seconds = 60
+  }
+}
+
+# resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
+#   provider  = aws.audit
+#   arn       = module.okta_audit_logs_lambda.arn
+#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+#   target_id = "okta_audit_logs_lambda"
+# 
+#   retry_policy {
+#     maximum_retry_attempts       = 3
+#     maximum_event_age_in_seconds = 60
+#   }
+# }
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_audit_lambda" {
+  for_each     = local.audit_lambdas
+  provider     = aws.audit
+  statement_id = "Allow${each.value}AuditLambdaExecutionFromCloudWatch"
+  action       = "lambda:InvokeFunction"
+  #function_name = local.audit_lambda_names[each.key]
+  function_name = module.terraform_cloud_audit_logs_lambda.name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.audit_trigger_daily.arn
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,3 +1,4 @@
+# Generic
 resource "aws_cloudwatch_event_rule" "audit_trigger_daily" {
   provider            = aws.audit
   name                = "audit-trigger-daily"
@@ -5,18 +6,17 @@ resource "aws_cloudwatch_event_rule" "audit_trigger_daily" {
   schedule_expression = "cron(0 9 ? * * *)"
 }
 
-# resource "aws_cloudwatch_event_target" "gitlab_audit_trigger_daily" {
-#   provider  = aws.audit
-#   arn       = module.gitlab_audit_logs_lambda.arn
-#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
-#   target_id = "gitlab_audit_logs_lambda"
-# 
-#   retry_policy {
-#     maximum_retry_attempts       = 3
-#     maximum_event_age_in_seconds = 60
-#   }
-# }
+resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_audit_lambda" {
+  for_each      = local.audit_lambdas
+  provider      = aws.audit
+  statement_id  = "Allow${each.value}AuditLambdaExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = local.audit_lambda_names[each.key]
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.audit_trigger_daily.arn
+}
 
+# Terraform
 resource "aws_cloudwatch_event_target" "terraform_audit_trigger_daily" {
   provider  = aws.audit
   arn       = module.terraform_cloud_audit_logs_lambda.arn
@@ -33,6 +33,7 @@ resource "aws_cloudwatch_event_target" "terraform_audit_trigger_daily" {
   }
 }
 
+# Okta
 resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
   provider  = aws.audit
   arn       = module.okta_audit_logs_lambda.arn
@@ -45,13 +46,15 @@ resource "aws_cloudwatch_event_target" "okta_audit_trigger_daily" {
   }
 }
 
-resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_audit_lambda" {
-  for_each      = local.audit_lambdas
-  provider      = aws.audit
-  statement_id  = "Allow${each.value}AuditLambdaExecutionFromCloudWatch"
-  action        = "lambda:InvokeFunction"
-  function_name = local.audit_lambda_names[each.key]
-  #function_name = module.terraform_cloud_audit_logs_lambda.name
-  principal  = "events.amazonaws.com"
-  source_arn = aws_cloudwatch_event_rule.audit_trigger_daily.arn
-}
+# # Gitlab
+# resource "aws_cloudwatch_event_target" "gitlab_audit_trigger_daily" {
+#   provider  = aws.audit
+#   arn       = module.gitlab_audit_logs_lambda.arn
+#   rule      = aws_cloudwatch_event_rule.audit_trigger_daily.name
+#   target_id = "gitlab_audit_logs_lambda"
+# 
+#   retry_policy {
+#     maximum_retry_attempts       = 3
+#     maximum_event_age_in_seconds = 60
+#   }
+# }

--- a/data.tf
+++ b/data.tf
@@ -104,18 +104,17 @@ data "aws_iam_policy_document" "okta_secret_access" {
   }
 }
 
-## Gitlab
-#data "aws_iam_policy_document" "gitlab_secret_access" {
-#  statement {
-#    sid = "AllowGitlabTokenSecret"
-#    actions = [
-#      "secretsmanager:GetSecretValue",
-#      "secretsmanager:DescribeSecret",
-#    ]
-#    effect = "Allow"
-#    resources = [
-#      aws_secretsmanager_secret.gitlab_token_secret.arn
-#    ]
-#  }
-#}
-
+# Gitlab
+data "aws_iam_policy_document" "gitlab_secret_access" {
+  statement {
+    sid = "AllowGitlabTokenSecret"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    effect = "Allow"
+    resources = [
+      aws_secretsmanager_secret.gitlab_token_secret.arn
+    ]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -101,16 +101,16 @@ data "aws_iam_policy_document" "terraform_secret_access" {
   }
 }
 
-# data "aws_iam_policy_document" "okta_secret_access" {
-#   statement {
-#     sid = "AllowGitlabTokenSecret"
-#     actions = [
-#       "secretsmanager:GetSecretValue",
-#       "secretsmanager:DescribeSecret",
-#     ]
-#     effect = "Allow"
-#     resources = [
-#       aws_secretsmanager_secret.okta_token_secret.arn
-#     ]
-#   }
-# }
+data "aws_iam_policy_document" "okta_secret_access" {
+  statement {
+    sid = "AllowGitlabTokenSecret"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    effect = "Allow"
+    resources = [
+      aws_secretsmanager_secret.okta_token_secret.arn
+    ]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,116 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "audit" {
+  provider = aws.audit
+}
+
+#data "aws_iam_policy_document" "gitlab_secret_access" {
+#  statement {
+#    sid = "AllowGitlabTokenSecret"
+#    actions = [
+#      "secretsmanager:GetSecretValue",
+#      "secretsmanager:DescribeSecret",
+#    ]
+#    effect = "Allow"
+#    resources = [
+#      aws_secretsmanager_secret.gitlab_token_secret.arn
+#    ]
+#  }
+#}
+
+data "aws_iam_policy_document" "lambda_kms_access" {
+  statement {
+    sid = "LambdaKMSAccess"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:ReEncryptTo",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:GenerateDataKeyPairWithoutPlaintext",
+      "kms:GenerateDataKeyPair",
+      "kms:ReEncryptFrom"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "lambda_to_s3" {
+  statement {
+    sid     = "LambdaUploadToS3"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.audit_logs_archive_bucket.arn}/gitlab_groups_audit_log/*",
+      "${module.audit_logs_archive_bucket.arn}/gitlab_projects_audit_log/*",
+      "${module.audit_logs_archive_bucket.arn}/terraform_logs/*",
+      "${module.audit_logs_archive_bucket.arn}/okta_logs/*"
+    ]
+  }
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "log_group_audit_logs" {
+  statement {
+    sid = "TrustEventsToStoreLogEvent"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${local.account_id}:*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "terraform_lambda_to_sqs" {
+  statement {
+    sid = "TerraformLambdaToFromSQS"
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:SendMessageBatch",
+      "sqs:SetQueueAttributes"
+    ]
+    effect = "Allow"
+    resources = [
+      aws_sqs_queue.terraform_audit_log_queue.arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "terraform_secret_access" {
+  statement {
+    sid = "AllowTerraformTokenSecret"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    effect = "Allow"
+    resources = [
+      aws_secretsmanager_secret.terraform_token_secret.arn
+    ]
+  }
+}
+
+# data "aws_iam_policy_document" "okta_secret_access" {
+#   statement {
+#     sid = "AllowGitlabTokenSecret"
+#     actions = [
+#       "secretsmanager:GetSecretValue",
+#       "secretsmanager:DescribeSecret",
+#     ]
+#     effect = "Allow"
+#     resources = [
+#       aws_secretsmanager_secret.okta_token_secret.arn
+#     ]
+#   }
+# }

--- a/data.tf
+++ b/data.tf
@@ -6,6 +6,8 @@ data "aws_caller_identity" "audit" {
 }
 
 data "aws_iam_policy_document" "lambda_kms_access" {
+  #checkov:skip=CKV_AWS_111: Access should be limited on KMS key
+  #checkov:skip=CKV_AWS_356: Access should be limited on KMS key
   statement {
     sid = "LambdaKMSAccess"
     actions = [
@@ -24,7 +26,6 @@ data "aws_iam_policy_document" "lambda_kms_access" {
 
 }
 
-#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "lambda_to_s3" {
   statement {
     sid     = "LambdaUploadToS3"
@@ -38,7 +39,6 @@ data "aws_iam_policy_document" "lambda_to_s3" {
   }
 }
 
-#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "log_group_audit_logs" {
   statement {
     sid = "TrustEventsToStoreLogEvent"

--- a/data.tf
+++ b/data.tf
@@ -1,22 +1,9 @@
+# Generic
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "audit" {
   provider = aws.audit
 }
-
-#data "aws_iam_policy_document" "gitlab_secret_access" {
-#  statement {
-#    sid = "AllowGitlabTokenSecret"
-#    actions = [
-#      "secretsmanager:GetSecretValue",
-#      "secretsmanager:DescribeSecret",
-#    ]
-#    effect = "Allow"
-#    resources = [
-#      aws_secretsmanager_secret.gitlab_token_secret.arn
-#    ]
-#  }
-#}
 
 data "aws_iam_policy_document" "lambda_kms_access" {
   statement {
@@ -68,6 +55,7 @@ data "aws_iam_policy_document" "log_group_audit_logs" {
   }
 }
 
+# Terraform
 data "aws_iam_policy_document" "terraform_lambda_to_sqs" {
   statement {
     sid = "TerraformLambdaToFromSQS"
@@ -101,6 +89,7 @@ data "aws_iam_policy_document" "terraform_secret_access" {
   }
 }
 
+# Okta
 data "aws_iam_policy_document" "okta_secret_access" {
   statement {
     sid = "AllowGitlabTokenSecret"
@@ -114,3 +103,19 @@ data "aws_iam_policy_document" "okta_secret_access" {
     ]
   }
 }
+
+## Gitlab
+#data "aws_iam_policy_document" "gitlab_secret_access" {
+#  statement {
+#    sid = "AllowGitlabTokenSecret"
+#    actions = [
+#      "secretsmanager:GetSecretValue",
+#      "secretsmanager:DescribeSecret",
+#    ]
+#    effect = "Allow"
+#    resources = [
+#      aws_secretsmanager_secret.gitlab_token_secret.arn
+#    ]
+#  }
+#}
+

--- a/iam.tf
+++ b/iam.tf
@@ -76,19 +76,19 @@ resource "aws_iam_policy" "terraform_secret_access" {
 resource "aws_iam_role_policy_attachment" "lambda_cloudwatch_group" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.lambda_cloudwatch_group.arn
-  role       = module.terraform_cloud_audit_logs_lambda.name
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_kms_access" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.lambda_kms_access.arn
-  role       = module.terraform_cloud_audit_logs_lambda.name
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.lambda_put_s3_bucket.arn
-  role       = module.terraform_cloud_audit_logs_lambda.name
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 # resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
@@ -106,11 +106,11 @@ resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
 resource "aws_iam_role_policy_attachment" "terraform_lambda_to_sqs" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.terraform_lambda_to_sqs.arn
-  role       = module.terraform_cloud_audit_logs_lambda.name
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 resource "aws_iam_role_policy_attachment" "terraform_secret_access" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.terraform_secret_access.arn
-  role       = module.terraform_cloud_audit_logs_lambda.name
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,25 +1,16 @@
-#resource "aws_iam_policy" "gitlab_secret_access" {
-#  provider    = aws.audit
-#  name        = "PolicyAllowGitlabTokenSecret"
-#  description = "Policy allowing lambda to read token from secrets"
-#  path        = "/"
-#  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
-#}
-#
-resource "aws_iam_policy" "okta_secret_access" {
-  provider    = aws.audit
-  name        = "PolicyAllowOktaTokenSecret"
-  description = "Policy allowing lambda to read token from secrets"
-  path        = "/"
-  policy      = data.aws_iam_policy_document.okta_secret_access.json
-}
-
+# Generic
 resource "aws_iam_policy" "lambda_cloudwatch_group" {
   provider    = aws.audit
   name        = "PolicyLambdaCloudWatchLogGroup"
   description = "Policy allowing lambda to store logs to CloudWatch log group"
   path        = "/"
   policy      = data.aws_iam_policy_document.log_group_audit_logs.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cloudwatch_group" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_cloudwatch_group.arn
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 resource "aws_iam_policy" "lambda_kms_access" {
@@ -30,6 +21,12 @@ resource "aws_iam_policy" "lambda_kms_access" {
   policy      = data.aws_iam_policy_document.lambda_kms_access.json
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_kms_access" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_kms_access.arn
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
+}
+
 resource "aws_iam_policy" "lambda_put_s3_bucket" {
   provider    = aws.audit
   name        = "PolicyLambdaPutToS3"
@@ -38,12 +35,25 @@ resource "aws_iam_policy" "lambda_put_s3_bucket" {
   policy      = data.aws_iam_policy_document.lambda_to_s3.json
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_put_s3_bucket.arn
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
+}
+
+# Terraform
 resource "aws_iam_policy" "terraform_lambda_to_sqs" {
   provider    = aws.audit
   name        = "PolicyTerraformLambdaToFromSQS"
   description = "Policy allowing lambda to read/send messages to/from sqs"
   path        = "/"
   policy      = data.aws_iam_policy_document.terraform_lambda_to_sqs.json
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_lambda_to_sqs" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.terraform_lambda_to_sqs.arn
+  role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
 resource "aws_iam_policy" "terraform_secret_access" {
@@ -54,63 +64,40 @@ resource "aws_iam_policy" "terraform_secret_access" {
   policy      = data.aws_iam_policy_document.terraform_secret_access.json
 }
 
-#resource "aws_iam_role" "role_lambda_audit_logs" {
-#  for_each = local.audit_lambdas
-#  provider = aws.audit
-#  name     = "Role${each.value}AuditLogsLambda"
-#
-#  assume_role_policy = jsonencode(
-#    {
-#      "Version" : "2012-10-17",
-#      "Statement" : [{
-#        "Action" : "sts:AssumeRole",
-#        "Principal" : {
-#          "Service" : "lambda.amazonaws.com"
-#        },
-#        "Effect" : "Allow"
-#      }]
-#    }
-#  )
-#}
-
-resource "aws_iam_role_policy_attachment" "lambda_cloudwatch_group" {
+resource "aws_iam_role_policy_attachment" "terraform_secret_access" {
   provider   = aws.audit
-  policy_arn = aws_iam_policy.lambda_cloudwatch_group.arn
+  policy_arn = aws_iam_policy.terraform_secret_access.arn
   role       = module.terraform_cloud_audit_logs_lambda.role_name
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_kms_access" {
-  provider   = aws.audit
-  policy_arn = aws_iam_policy.lambda_kms_access.arn
-  role       = module.terraform_cloud_audit_logs_lambda.role_name
+# Okta
+resource "aws_iam_policy" "okta_secret_access" {
+  provider    = aws.audit
+  name        = "PolicyAllowOktaTokenSecret"
+  description = "Policy allowing lambda to read token from secrets"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.okta_secret_access.json
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
-  provider   = aws.audit
-  policy_arn = aws_iam_policy.lambda_put_s3_bucket.arn
-  role       = module.terraform_cloud_audit_logs_lambda.role_name
-}
-
-# resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
-#   provider   = aws.audit
-#   policy_arn = aws_iam_policy.gitlab_secret_access.arn
-#   role       = aws_iam_role.role_lambda_audit_logs["gitlab"].name
-# }
-# 
 resource "aws_iam_role_policy_attachment" "okta_secret_access" {
   provider   = aws.audit
   policy_arn = aws_iam_policy.okta_secret_access.arn
   role       = module.okta_audit_logs_lambda.role_name
 }
 
-resource "aws_iam_role_policy_attachment" "terraform_lambda_to_sqs" {
-  provider   = aws.audit
-  policy_arn = aws_iam_policy.terraform_lambda_to_sqs.arn
-  role       = module.terraform_cloud_audit_logs_lambda.role_name
-}
+# # Gitlab
+# resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
+#   provider   = aws.audit
+#   policy_arn = aws_iam_policy.gitlab_secret_access.arn
+#   role       = aws_iam_role.role_lambda_audit_logs["gitlab"].name
+# }
+# 
 
-resource "aws_iam_role_policy_attachment" "terraform_secret_access" {
-  provider   = aws.audit
-  policy_arn = aws_iam_policy.terraform_secret_access.arn
-  role       = module.terraform_cloud_audit_logs_lambda.role_name
-}
+#resource "aws_iam_policy" "gitlab_secret_access" {
+#  provider    = aws.audit
+#  name        = "PolicyAllowGitlabTokenSecret"
+#  description = "Policy allowing lambda to read token from secrets"
+#  path        = "/"
+#  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
+#}
+#

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,116 @@
+#resource "aws_iam_policy" "gitlab_secret_access" {
+#  provider    = aws.audit
+#  name        = "PolicyAllowGitlabTokenSecret"
+#  description = "Policy allowing lambda to read token from secrets"
+#  path        = "/"
+#  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
+#}
+#
+#resource "aws_iam_policy" "okta_secret_access" {
+#  provider    = aws.audit
+#  name        = "PolicyAllowOktaTokenSecret"
+#  description = "Policy allowing lambda to read token from secrets"
+#  path        = "/"
+#  policy      = data.aws_iam_policy_document.okta_secret_access.json
+#}
+#
+resource "aws_iam_policy" "lambda_cloudwatch_group" {
+  provider    = aws.audit
+  name        = "PolicyLambdaCloudWatchLogGroup"
+  description = "Policy allowing lambda to store logs to CloudWatch log group"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.log_group_audit_logs.json
+}
+
+resource "aws_iam_policy" "lambda_kms_access" {
+  provider    = aws.audit
+  name        = "PolicyLambdaKMSAccess"
+  description = "Policy allowing lambda to encrypt/decrypt messages using KMS"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.lambda_kms_access.json
+}
+
+resource "aws_iam_policy" "lambda_put_s3_bucket" {
+  provider    = aws.audit
+  name        = "PolicyLambdaPutToS3"
+  description = "Policy allowing lambda to put logs into S3 bucket"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.lambda_to_s3.json
+}
+
+resource "aws_iam_policy" "terraform_lambda_to_sqs" {
+  provider    = aws.audit
+  name        = "PolicyTerraformLambdaToFromSQS"
+  description = "Policy allowing lambda to read/send messages to/from sqs"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.terraform_lambda_to_sqs.json
+}
+
+resource "aws_iam_policy" "terraform_secret_access" {
+  provider    = aws.audit
+  name        = "PolicyAllowTerraformTokenSecret"
+  description = "Policy allowing lambda to read token from secrets"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.terraform_secret_access.json
+}
+
+#resource "aws_iam_role" "role_lambda_audit_logs" {
+#  for_each = local.audit_lambdas
+#  provider = aws.audit
+#  name     = "Role${each.value}AuditLogsLambda"
+#
+#  assume_role_policy = jsonencode(
+#    {
+#      "Version" : "2012-10-17",
+#      "Statement" : [{
+#        "Action" : "sts:AssumeRole",
+#        "Principal" : {
+#          "Service" : "lambda.amazonaws.com"
+#        },
+#        "Effect" : "Allow"
+#      }]
+#    }
+#  )
+#}
+
+resource "aws_iam_role_policy_attachment" "lambda_cloudwatch_group" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_cloudwatch_group.arn
+  role       = module.terraform_cloud_audit_logs_lambda.name
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_kms_access" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_kms_access.arn
+  role       = module.terraform_cloud_audit_logs_lambda.name
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.lambda_put_s3_bucket.arn
+  role       = module.terraform_cloud_audit_logs_lambda.name
+}
+
+# resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
+#   provider   = aws.audit
+#   policy_arn = aws_iam_policy.gitlab_secret_access.arn
+#   role       = aws_iam_role.role_lambda_audit_logs["gitlab"].name
+# }
+# 
+# resource "aws_iam_role_policy_attachment" "okta_secret_access" {
+#   provider   = aws.audit
+#   policy_arn = aws_iam_policy.okta_secret_access.arn
+#   role       = aws_iam_role.role_lambda_audit_logs["okta"].name
+# }
+
+resource "aws_iam_role_policy_attachment" "terraform_lambda_to_sqs" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.terraform_lambda_to_sqs.arn
+  role       = module.terraform_cloud_audit_logs_lambda.name
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_secret_access" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.terraform_secret_access.arn
+  role       = module.terraform_cloud_audit_logs_lambda.name
+}

--- a/iam.tf
+++ b/iam.tf
@@ -85,19 +85,17 @@ resource "aws_iam_role_policy_attachment" "okta_secret_access" {
   role       = module.okta_audit_logs_lambda.role_name
 }
 
-# # Gitlab
-# resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
-#   provider   = aws.audit
-#   policy_arn = aws_iam_policy.gitlab_secret_access.arn
-#   role       = aws_iam_role.role_lambda_audit_logs["gitlab"].name
-# }
-# 
+# Gitlab
+resource "aws_iam_policy" "gitlab_secret_access" {
+  provider    = aws.audit
+  name        = "PolicyAllowGitlabTokenSecret"
+  description = "Policy allowing lambda to read token from secrets"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
+}
 
-#resource "aws_iam_policy" "gitlab_secret_access" {
-#  provider    = aws.audit
-#  name        = "PolicyAllowGitlabTokenSecret"
-#  description = "Policy allowing lambda to read token from secrets"
-#  path        = "/"
-#  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
-#}
-#
+resource "aws_iam_role_policy_attachment" "gitlab_secret_access" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.gitlab_secret_access.arn
+  role       = module.gitlab_audit_logs_lambda.role_name
+}

--- a/iam.tf
+++ b/iam.tf
@@ -6,14 +6,14 @@
 #  policy      = data.aws_iam_policy_document.gitlab_secret_access.json
 #}
 #
-#resource "aws_iam_policy" "okta_secret_access" {
-#  provider    = aws.audit
-#  name        = "PolicyAllowOktaTokenSecret"
-#  description = "Policy allowing lambda to read token from secrets"
-#  path        = "/"
-#  policy      = data.aws_iam_policy_document.okta_secret_access.json
-#}
-#
+resource "aws_iam_policy" "okta_secret_access" {
+  provider    = aws.audit
+  name        = "PolicyAllowOktaTokenSecret"
+  description = "Policy allowing lambda to read token from secrets"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.okta_secret_access.json
+}
+
 resource "aws_iam_policy" "lambda_cloudwatch_group" {
   provider    = aws.audit
   name        = "PolicyLambdaCloudWatchLogGroup"
@@ -97,11 +97,11 @@ resource "aws_iam_role_policy_attachment" "lambda_put_s3_bucket" {
 #   role       = aws_iam_role.role_lambda_audit_logs["gitlab"].name
 # }
 # 
-# resource "aws_iam_role_policy_attachment" "okta_secret_access" {
-#   provider   = aws.audit
-#   policy_arn = aws_iam_policy.okta_secret_access.arn
-#   role       = aws_iam_role.role_lambda_audit_logs["okta"].name
-# }
+resource "aws_iam_role_policy_attachment" "okta_secret_access" {
+  provider   = aws.audit
+  policy_arn = aws_iam_policy.okta_secret_access.arn
+  role       = module.okta_audit_logs_lambda.role_name
+}
 
 resource "aws_iam_role_policy_attachment" "terraform_lambda_to_sqs" {
   provider   = aws.audit

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  audit_lambdas = {
+    #    gitlab = "GitLab"
+    terraform = "TerraformCloud"
+    #    okta      = "Okta"
+  }
+  audit_lambda_names = {
+    #    gitlab = "gitlab_audit_logs"
+    terraform = "terraform_cloud_audit_logs"
+    #    okta      = "okta_audit_logs"
+  }
+  environment = {
+    gitlab_api_url         = "https://gitlab.com/api/v4"
+    gitlab_token_secret    = "/audit-log-tokens/gitlab"
+    okta_token_secret      = "/audit-log-tokens/okta"
+    terraform_api_url      = "https://app.terraform.io/api/v2/organization/audit-trail"
+    terraform_token_secret = "/audit-log-tokens/terraform"
+  }
+  account_id = data.aws_caller_identity.audit.account_id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -2,12 +2,12 @@ locals {
   audit_lambdas = {
     #    gitlab = "GitLab"
     terraform = "TerraformCloud"
-    #    okta      = "Okta"
+    okta      = "Okta"
   }
   audit_lambda_names = {
     #    gitlab = "gitlab_audit_logs"
     terraform = "terraform_cloud_audit_logs"
-    #    okta      = "okta_audit_logs"
+    okta      = "okta_audit_logs"
   }
   environment = {
     gitlab_api_url         = "https://gitlab.com/api/v4"

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,12 @@
 locals {
   audit_lambdas = {
-    #    gitlab = "GitLab"
+    gitlab    = "GitLab"
     terraform = "TerraformCloud"
     okta      = "Okta"
   }
 
   audit_lambda_names = {
-    #    gitlab = "gitlab_audit_logs"
+    gitlab    = "gitlab_audit_logs"
     terraform = "terraform_cloud_audit_logs"
     okta      = "okta_audit_logs"
   }

--- a/locals.tf
+++ b/locals.tf
@@ -4,11 +4,13 @@ locals {
     terraform = "TerraformCloud"
     okta      = "Okta"
   }
+
   audit_lambda_names = {
     #    gitlab = "gitlab_audit_logs"
     terraform = "terraform_cloud_audit_logs"
     okta      = "okta_audit_logs"
   }
+
   environment = {
     gitlab_api_url         = "https://gitlab.com/api/v4"
     gitlab_token_secret    = "/audit-log-tokens/gitlab"
@@ -16,5 +18,6 @@ locals {
     terraform_api_url      = "https://app.terraform.io/api/v2/organization/audit-trail"
     terraform_token_secret = "/audit-log-tokens/terraform"
   }
+
   account_id = data.aws_caller_identity.audit.account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 locals {
   s3_object_keys = {
-    terraform = "terraformcloud/${element(split("/", module.lambda_terraform_deployment_package.local_filename), length(split("/", module.lambda_terraform_deployment_package.local_filename)) - 1)}"
+    gitlab    = "gitlab/${element(split("/", module.lambda_gitlab_deployment_package.local_filename), length(split("/", module.lambda_gitlab_deployment_package.local_filename)) - 1)}"
     okta      = "okta/${element(split("/", module.lambda_okta_deployment_package.local_filename), length(split("/", module.lambda_okta_deployment_package.local_filename)) - 1)}"
+    terraform = "terraformcloud/${element(split("/", module.lambda_terraform_deployment_package.local_filename), length(split("/", module.lambda_terraform_deployment_package.local_filename)) - 1)}"
   }
 }
 
@@ -106,56 +107,53 @@ module "okta_audit_logs_lambda" {
   }
 }
 
-# # Gitlab
-# module "lambda_gitlab_deployment_package" {
-#   providers                = { aws = aws.audit }
-#   source                   = "terraform-aws-modules/lambda/aws"
-#   version                  = "~> 6.4.0"
-#   create_function          = false
-#   recreate_missing_package = false
-#   runtime                  = "python${var.python_version}"
-#   s3_bucket                = module.lambda_deployment_package_bucket.name
-#   s3_object_storage_class  = "STANDARD"
-#   source_path              = "src/gitlab"
-#   store_on_s3              = true
-#   artifacts_dir            = "gitlab"
-# }
-# 
-# resource "aws_s3_object" "lambda_okta_deployment_package" {
-#   provider   = aws.audit
-#   bucket     = module.lambda_deployment_package_bucket.name
-#   key        = local.s3_object_keys.okta
-#   kms_key_id = var.kms_key_arn
-#   source     = module.lambda_okta_deployment_package.local_filename
-# }
-#
-# module "gitlab_audit_logs_lambda" {
-#   #checkov:skip=CKV_AWS_272:Code signing not used for now
-#   providers              = { aws = aws.audit }
-#   source                 = "schubergphilis/mcaf-lambda/aws"
-#   version                = "~> 1.1.0"
-#   name                   = local.audit_lambda_names.gitlab
-#   create_policy          = false
-#   create_s3_dummy_object = false
-#   description            = "Lambda for gathering audit logs from gitlab and storing them in S3"
-#   filename               = module.lambda_gitlab_deployment_package.local_filename
-#   handler                = "${local.audit_lambda_names.gitlab}.handler"
-#   kms_key_arn            = var.kms_key_arn
-#   log_retention          = 365
-#   memory_size            = 512
-#   role_arn               = aws_iam_role.role_lambda_audit_logs["gitlab"].arn
-#   runtime                = "python${var.python_version}"
-#   s3_bucket              = module.lambda_deployment_package_bucket.name
-#   s3_key                 = module.lambda_gitlab_deployment_package.s3_object.key
-#   s3_object_version      = module.lambda_gitlab_deployment_package.s3_object.version_id
-#   tags                   = {}
-#   timeout                = 600
-# 
-#   environment = {
-#     token_secret_name  = local.environment.gitlab_token_secret
-#     logs_bucket        = module.audit_logs_archive_bucket.name
-#     logs_url           = local.environment.gitlab_api_url
-#     log_level          = "info"
-#     days_of_audit_logs = 1
-#   }
-# }
+# Gitlab
+module "lambda_gitlab_deployment_package" {
+  providers                = { aws = aws.audit }
+  source                   = "terraform-aws-modules/lambda/aws"
+  version                  = "~> 7.2.5"
+  create_function          = false
+  recreate_missing_package = false
+  runtime                  = "python${var.python_version}"
+  source_path              = "${path.module}/src/gitlab"
+  artifacts_dir            = "${path.root}/package/gitlab"
+}
+
+resource "aws_s3_object" "lambda_gitlab_deployment_package" {
+  provider   = aws.audit
+  bucket     = module.lambda_deployment_package_bucket.name
+  key        = local.s3_object_keys.gitlab
+  kms_key_id = var.kms_key_arn
+  source     = module.lambda_gitlab_deployment_package.local_filename
+}
+
+module "gitlab_audit_logs_lambda" {
+  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  providers = { aws = aws.audit }
+  #source                 = "schubergphilis/mcaf-lambda/aws"
+  #version                = "~> 1.2.1"
+  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/gitlab-aws-mcaf-lambda/pull/73
+  name                   = local.audit_lambda_names.gitlab
+  create_policy          = false
+  create_s3_dummy_object = false
+  description            = "Lambda for gathering audit logs from gitlab and storing them in S3"
+  handler                = "${local.audit_lambda_names.gitlab}.handler"
+  kms_key_arn            = var.kms_key_arn
+  log_retention          = 365
+  memory_size            = 512
+  runtime                = "python${var.python_version}"
+  s3_bucket              = "${var.bucket_base_name}-lambda-${local.account_id}"
+  s3_key                 = local.s3_object_keys.gitlab
+  s3_object_version      = aws_s3_object.lambda_gitlab_deployment_package.version_id
+  source_code_hash       = aws_s3_object.lambda_gitlab_deployment_package.checksum_sha256
+  tags                   = {}
+  timeout                = 600
+
+  environment = {
+    days_of_audit_logs = 1
+    log_level          = "info"
+    logs_bucket        = module.audit_logs_archive_bucket.name
+    logs_url           = local.environment.gitlab_api_url
+    token_secret_name  = local.environment.gitlab_token_secret
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -29,10 +29,9 @@ resource "aws_s3_object" "lambda_terraform_deployment_package" {
 
 module "terraform_cloud_audit_logs_lambda" {
   #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
-  providers = { aws = aws.audit }
-  #source                 = "schubergphilis/mcaf-lambda/aws"
-  #version                = "~> 1.2.1"
-  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/terraform-aws-mcaf-lambda/pull/73
+  providers              = { aws = aws.audit }
+  source                 = "schubergphilis/mcaf-lambda/aws"
+  version                = "~> 1.3.0"
   name                   = local.audit_lambda_names.terraform
   create_policy          = false
   create_s3_dummy_object = false
@@ -81,10 +80,9 @@ resource "aws_s3_object" "lambda_okta_deployment_package" {
 
 module "okta_audit_logs_lambda" {
   #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
-  providers = { aws = aws.audit }
-  #source                 = "schubergphilis/mcaf-lambda/aws"
-  #version                = "~> 1.2.1"
-  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/okta-aws-mcaf-lambda/pull/73
+  providers              = { aws = aws.audit }
+  source                 = "schubergphilis/mcaf-lambda/aws"
+  version                = "~> 1.3.0"
   name                   = local.audit_lambda_names.okta
   create_policy          = false
   create_s3_dummy_object = false
@@ -132,10 +130,9 @@ resource "aws_s3_object" "lambda_gitlab_deployment_package" {
 
 module "gitlab_audit_logs_lambda" {
   #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
-  providers = { aws = aws.audit }
-  #source                 = "schubergphilis/mcaf-lambda/aws"
-  #version                = "~> 1.2.1"
-  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/gitlab-aws-mcaf-lambda/pull/73
+  providers              = { aws = aws.audit }
+  source                 = "schubergphilis/mcaf-lambda/aws"
+  version                = "~> 1.3.0"
   name                   = local.audit_lambda_names.gitlab
   create_policy          = false
   create_s3_dummy_object = false

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "audit_logs_archive_bucket" {
   kms_key_arn       = var.kms_key_arn
 
   logging = {
-    target_bucket = "ep-audit-logs-logging-${local.account_id}"
+    target_bucket = module.audit_logs_archive_logging_bucket.name
     target_prefix = "ep-audit-logs/"
   }
 
@@ -111,19 +111,19 @@ module "lambda_deployment_package_bucket" {
   ]
 }
 
-#module "lambda_terraform_deployment_package" {
-#  providers                = { aws = aws.audit }
-#  source                   = "terraform-aws-modules/lambda/aws"
-#  version                  = "~> 6.4.0"
-#  create_function          = false
-#  recreate_missing_package = false
-#  runtime                  = "python3.12"
-#  s3_bucket                = module.lambda_deployment_package_bucket.name
-#  s3_object_storage_class  = "STANDARD"
-#  source_path              = "${path.module}/src/terraformcloud"
-#  store_on_s3              = true
-#  artifacts_dir            = "terraformcloud"
-#}
+module "lambda_terraform_deployment_package" {
+  providers                = { aws = aws.audit }
+  source                   = "terraform-aws-modules/lambda/aws"
+  version                  = "~> 7.2.5"
+  create_function          = false
+  recreate_missing_package = false
+  runtime                  = "python3.12"
+  s3_bucket                = module.lambda_deployment_package_bucket.name
+  s3_object_storage_class  = "STANDARD"
+  source_path              = "${path.module}/src/terraformcloud"
+  store_on_s3              = true
+  artifacts_dir            = "terraformcloud"
+}
 
 data "archive_file" "lambda_terraform_zip" {
   type        = "zip"
@@ -141,9 +141,10 @@ resource "aws_s3_object" "lambda_terraform_deployment_package" {
 
 module "terraform_cloud_audit_logs_lambda" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
-  providers              = { aws = aws.audit }
-  source                 = "schubergphilis/mcaf-lambda/aws"
-  version                = "~> 1.2.1"
+  providers = { aws = aws.audit }
+  #source                 = "schubergphilis/mcaf-lambda/aws"
+  #version                = "~> 1.2.1"
+  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/terraform-aws-mcaf-lambda/pull/73
   name                   = local.audit_lambda_names.terraform
   create_policy          = false
   create_s3_dummy_object = false

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,259 @@
+module "audit_logs_archive_bucket" {
+  providers         = { aws = aws.audit }
+  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name              = "ep-audit-logs-${local.account_id}"
+  object_lock_mode  = "COMPLIANCE"
+  object_lock_years = 1
+  versioning        = true
+  tags              = {}
+  kms_key_arn       = var.kms_key_arn
+
+  logging = {
+    target_bucket = "ep-audit-logs-logging-${local.account_id}"
+    target_prefix = "ep-audit-logs/"
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 14
+      }
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 365
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 90
+        storage_class   = "INTELLIGENT_TIERING"
+      }
+
+      transition = {
+        days          = 90
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  ]
+}
+
+module "audit_logs_archive_logging_bucket" {
+  providers         = { aws = aws.audit }
+  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name              = "ep-audit-logs-logging-${local.account_id}"
+  object_lock_mode  = "COMPLIANCE"
+  object_lock_years = 1
+  versioning        = true
+  tags              = {}
+  kms_key_arn       = var.kms_key_arn
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 14
+      }
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 365
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 90
+        storage_class   = "INTELLIGENT_TIERING"
+      }
+
+      transition = {
+        days          = 90
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  ]
+}
+
+module "lambda_deployment_package_bucket" {
+  providers   = { aws = aws.audit }
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
+  name        = "ep-audit-logs-lambda-deployments-${local.account_id}"
+  versioning  = true
+  tags        = {}
+  kms_key_arn = var.kms_key_arn
+
+  lifecycle_rule = [
+    {
+      id      = "default"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 7
+      }
+
+      expiration = {
+        expired_object_delete_marker = true
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 7
+      }
+    }
+  ]
+}
+
+#module "lambda_terraform_deployment_package" {
+#  providers                = { aws = aws.audit }
+#  source                   = "terraform-aws-modules/lambda/aws"
+#  version                  = "~> 6.4.0"
+#  create_function          = false
+#  recreate_missing_package = false
+#  runtime                  = "python3.12"
+#  s3_bucket                = module.lambda_deployment_package_bucket.name
+#  s3_object_storage_class  = "STANDARD"
+#  source_path              = "${path.module}/src/terraformcloud"
+#  store_on_s3              = true
+#  artifacts_dir            = "terraformcloud"
+#}
+
+data "archive_file" "lambda_terraform_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/terraformcloud"
+  output_path = "${path.module}/src/terraformcloud.zip"
+}
+
+resource "aws_s3_object" "lambda_terraform_deployment_package" {
+  bucket     = module.lambda_deployment_package_bucket.name
+  key        = "terraformcloud.zip"
+  kms_key_id = var.kms_key_arn
+  source     = data.archive_file.lambda_terraform_zip.output_path
+}
+
+module "terraform_cloud_audit_logs_lambda" {
+  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  providers              = { aws = aws.audit }
+  source                 = "schubergphilis/mcaf-lambda/aws"
+  version                = "~> 1.2.1"
+  name                   = local.audit_lambda_names.terraform
+  create_policy          = false
+  create_s3_dummy_object = false
+  description            = "Lambda for gathering audit logs from terraform cloud and storing them in S3"
+  filename               = data.archive_file.lambda_terraform_zip.output_path
+  handler                = "${local.audit_lambda_names.terraform}.handler"
+  kms_key_arn            = var.kms_key_arn
+  log_retention          = 365
+  memory_size            = 512
+  runtime                = "python3.12"
+  s3_bucket              = "ep-audit-logs-lambda-${local.account_id}" #TODO parameterise
+  s3_key                 = aws_s3_object.lambda_terraform_deployment_package.key
+  s3_object_version      = aws_s3_object.lambda_terraform_deployment_package.version_id
+  source_code_hash       = data.archive_file.lambda_terraform_zip.output_base64sha256
+  tags                   = {}
+  timeout                = 600
+
+  environment = {
+    token_secret_name = local.environment.terraform_token_secret
+    logs_bucket       = module.audit_logs_archive_bucket.name
+    logs_url          = local.environment.terraform_api_url
+    queue_url         = aws_sqs_queue.terraform_audit_log_queue.id
+    file_prefix       = "terraform_logs/"
+  }
+}
+
+#module "lambda_gitlab_deployment_package" {
+#  providers                = { aws = aws.audit }
+#  source                   = "terraform-aws-modules/lambda/aws"
+#  version                  = "~> 6.4.0"
+#  create_function          = false
+#  recreate_missing_package = false
+#  runtime                  = "python3.12"
+#  s3_bucket                = module.lambda_deployment_package_bucket.name
+#  s3_object_storage_class  = "STANDARD"
+#  source_path              = "src/gitlab"
+#  store_on_s3              = true
+#  artifacts_dir            = "gitlab"
+#}
+#
+#module "lambda_okta_deployment_package" {
+#  providers                = { aws = aws.audit }
+#  source                   = "terraform-aws-modules/lambda/aws"
+#  version                  = "~> 6.4.0"
+#  create_function          = false
+#  recreate_missing_package = false
+#  runtime                  = "python3.12"
+#  s3_bucket                = module.lambda_deployment_package_bucket.name
+#  s3_object_storage_class  = "STANDARD"
+#  source_path              = "src/okta"
+#  store_on_s3              = true
+#  artifacts_dir            = "okta"
+#}
+
+# module "gitlab_audit_logs_lambda" {
+#   #checkov:skip=CKV_AWS_272:Code signing not used for now
+#   providers              = { aws = aws.audit }
+#   source                 = "schubergphilis/mcaf-lambda/aws"
+#   version                = "~> 1.1.0"
+#   name                   = local.audit_lambda_names.gitlab
+#   create_policy          = false
+#   create_s3_dummy_object = false
+#   description            = "Lambda for gathering audit logs from gitlab and storing them in S3"
+#   filename               = module.lambda_gitlab_deployment_package.local_filename
+#   handler                = "${local.audit_lambda_names.gitlab}.handler"
+#   kms_key_arn            = var.kms_key_arn
+#   log_retention          = 365
+#   memory_size            = 512
+#   role_arn               = aws_iam_role.role_lambda_audit_logs["gitlab"].arn
+#   runtime                = "python3.12"
+#   s3_bucket              = module.lambda_deployment_package_bucket.name
+#   s3_key                 = module.lambda_gitlab_deployment_package.s3_object.key
+#   s3_object_version      = module.lambda_gitlab_deployment_package.s3_object.version_id
+#   tags                   = {}
+#   timeout                = 600
+# 
+#   environment = {
+#     token_secret_name  = local.environment.gitlab_token_secret
+#     logs_bucket        = module.audit_logs_archive_bucket.name
+#     logs_url           = local.environment.gitlab_api_url
+#     log_level          = "info"
+#     days_of_audit_logs = 1
+#   }
+# }
+
+#module "okta_audit_logs_lambda" {
+#  #checkov:skip=CKV_AWS_272:Code signing not used for now
+#  providers              = { aws = aws.audit }
+#  source                 = "schubergphilis/mcaf-lambda/aws"
+#  version                = "~> 1.1.0"
+#  name                   = local.audit_lambda_names.okta
+#  create_policy          = false
+#  create_s3_dummy_object = false
+#  description            = "Lambda for gathering audit logs from Okta and storing them in S3"
+#  filename               = module.lambda_okta_deployment_package.local_filename
+#  handler                = "${local.audit_lambda_names.okta}.handler"
+#  kms_key_arn            = var.kms_key_arn
+#  log_retention          = 365
+#  memory_size            = 512
+#  role_arn               = aws_iam_role.role_lambda_audit_logs["okta"].arn
+#  runtime                = "python3.12"
+#  s3_bucket              = module.lambda_deployment_package_bucket.name
+#  s3_key                 = module.lambda_okta_deployment_package.s3_object.key
+#  s3_object_version      = module.lambda_okta_deployment_package.s3_object.version_id
+#  tags                   = {}
+#  timeout                = 600
+#
+#  environment = {
+#    token_secret_name = local.environment.okta_token_secret
+#    logs_bucket       = module.audit_logs_archive_bucket.name
+#    log_level         = "info"
+#    file_prefix       = "okta_logs/"
+#  }
+#}

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
 
 # Terraform
 module "lambda_terraform_deployment_package" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers                = { aws = aws.audit }
   source                   = "terraform-aws-modules/lambda/aws"
   version                  = "~> 7.2.5"
@@ -27,7 +28,7 @@ resource "aws_s3_object" "lambda_terraform_deployment_package" {
 }
 
 module "terraform_cloud_audit_logs_lambda" {
-  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers = { aws = aws.audit }
   #source                 = "schubergphilis/mcaf-lambda/aws"
   #version                = "~> 1.2.1"
@@ -59,6 +60,7 @@ module "terraform_cloud_audit_logs_lambda" {
 
 # Okta
 module "lambda_okta_deployment_package" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers                = { aws = aws.audit }
   source                   = "terraform-aws-modules/lambda/aws"
   version                  = "~> 7.2.5"
@@ -78,7 +80,7 @@ resource "aws_s3_object" "lambda_okta_deployment_package" {
 }
 
 module "okta_audit_logs_lambda" {
-  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers = { aws = aws.audit }
   #source                 = "schubergphilis/mcaf-lambda/aws"
   #version                = "~> 1.2.1"
@@ -109,6 +111,7 @@ module "okta_audit_logs_lambda" {
 
 # Gitlab
 module "lambda_gitlab_deployment_package" {
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers                = { aws = aws.audit }
   source                   = "terraform-aws-modules/lambda/aws"
   version                  = "~> 7.2.5"
@@ -128,7 +131,7 @@ resource "aws_s3_object" "lambda_gitlab_deployment_package" {
 }
 
 module "gitlab_audit_logs_lambda" {
-  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  #checkov:skip=CKV_TF_1:Registry uses commit hash (tags) as version
   providers = { aws = aws.audit }
   #source                 = "schubergphilis/mcaf-lambda/aws"
   #version                = "~> 1.2.1"

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@ module "audit_logs_archive_bucket" {
   providers         = { aws = aws.audit }
   source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
   name              = "ep-audit-logs-${local.account_id}"
-  object_lock_mode  = "COMPLIANCE"
-  object_lock_years = 1
+  object_lock_mode  = try(var.object_locking.mode, null)
+  object_lock_years = try(var.object_locking.years, null)
   versioning        = true
   tags              = {}
   kms_key_arn       = var.kms_key_arn
@@ -47,8 +47,8 @@ module "audit_logs_archive_logging_bucket" {
   providers         = { aws = aws.audit }
   source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
   name              = "ep-audit-logs-logging-${local.account_id}"
-  object_lock_mode  = "COMPLIANCE"
-  object_lock_years = 1
+  object_lock_mode  = try(var.object_locking.mode, null)
+  object_lock_years = try(var.object_locking.years, null)
   versioning        = true
   tags              = {}
   kms_key_arn       = var.kms_key_arn

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
   }
 }
 
+# Terraform
 module "lambda_terraform_deployment_package" {
   providers                = { aws = aws.audit }
   source                   = "terraform-aws-modules/lambda/aws"
@@ -55,6 +56,7 @@ module "terraform_cloud_audit_logs_lambda" {
   }
 }
 
+# Okta
 module "lambda_okta_deployment_package" {
   providers                = { aws = aws.audit }
   source                   = "terraform-aws-modules/lambda/aws"
@@ -104,19 +106,28 @@ module "okta_audit_logs_lambda" {
   }
 }
 
-#module "lambda_gitlab_deployment_package" {
-#  providers                = { aws = aws.audit }
-#  source                   = "terraform-aws-modules/lambda/aws"
-#  version                  = "~> 6.4.0"
-#  create_function          = false
-#  recreate_missing_package = false
-#  runtime                  = "python${var.python_version}"
-#  s3_bucket                = module.lambda_deployment_package_bucket.name
-#  s3_object_storage_class  = "STANDARD"
-#  source_path              = "src/gitlab"
-#  store_on_s3              = true
-#  artifacts_dir            = "gitlab"
-#}
+# # Gitlab
+# module "lambda_gitlab_deployment_package" {
+#   providers                = { aws = aws.audit }
+#   source                   = "terraform-aws-modules/lambda/aws"
+#   version                  = "~> 6.4.0"
+#   create_function          = false
+#   recreate_missing_package = false
+#   runtime                  = "python${var.python_version}"
+#   s3_bucket                = module.lambda_deployment_package_bucket.name
+#   s3_object_storage_class  = "STANDARD"
+#   source_path              = "src/gitlab"
+#   store_on_s3              = true
+#   artifacts_dir            = "gitlab"
+# }
+# 
+# resource "aws_s3_object" "lambda_okta_deployment_package" {
+#   provider   = aws.audit
+#   bucket     = module.lambda_deployment_package_bucket.name
+#   key        = local.s3_object_keys.okta
+#   kms_key_id = var.kms_key_arn
+#   source     = module.lambda_okta_deployment_package.local_filename
+# }
 #
 # module "gitlab_audit_logs_lambda" {
 #   #checkov:skip=CKV_AWS_272:Code signing not used for now

--- a/main.tf
+++ b/main.tf
@@ -1,114 +1,8 @@
-module "audit_logs_archive_bucket" {
-  providers         = { aws = aws.audit }
-  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
-  name              = "${var.bucket_base_name}-${local.account_id}"
-  object_lock_mode  = try(var.object_locking.mode, null)
-  object_lock_years = try(var.object_locking.years, null)
-  versioning        = true
-  tags              = {}
-  kms_key_arn       = var.kms_key_arn
-
-  logging = {
-    target_bucket = module.audit_logs_archive_logging_bucket.name
-    target_prefix = "ep-audit-logs/"
+locals {
+  s3_object_keys = {
+    terraform = "terraformcloud/${element(split("/", module.lambda_terraform_deployment_package.local_filename), length(split("/", module.lambda_terraform_deployment_package.local_filename)) - 1)}"
+    okta      = "okta/${element(split("/", module.lambda_okta_deployment_package.local_filename), length(split("/", module.lambda_okta_deployment_package.local_filename)) - 1)}"
   }
-
-  lifecycle_rule = [
-    {
-      id      = "retention"
-      enabled = true
-
-      abort_incomplete_multipart_upload = {
-        days_after_initiation = 14
-      }
-
-      expiration = {
-        days = 365
-      }
-
-      noncurrent_version_expiration = {
-        noncurrent_days = 365
-      }
-
-      noncurrent_version_transition = {
-        noncurrent_days = 90
-        storage_class   = "INTELLIGENT_TIERING"
-      }
-
-      transition = {
-        days          = 90
-        storage_class = "INTELLIGENT_TIERING"
-      }
-    }
-  ]
-}
-
-module "audit_logs_archive_logging_bucket" {
-  providers         = { aws = aws.audit }
-  source            = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
-  name              = "${var.bucket_base_name}-logging-${local.account_id}"
-  object_lock_mode  = try(var.object_locking.mode, null)
-  object_lock_years = try(var.object_locking.years, null)
-  versioning        = true
-  tags              = {}
-  kms_key_arn       = var.kms_key_arn
-
-  lifecycle_rule = [
-    {
-      id      = "retention"
-      enabled = true
-
-      abort_incomplete_multipart_upload = {
-        days_after_initiation = 14
-      }
-
-      expiration = {
-        days = 365
-      }
-
-      noncurrent_version_expiration = {
-        noncurrent_days = 365
-      }
-
-      noncurrent_version_transition = {
-        noncurrent_days = 90
-        storage_class   = "INTELLIGENT_TIERING"
-      }
-
-      transition = {
-        days          = 90
-        storage_class = "INTELLIGENT_TIERING"
-      }
-    }
-  ]
-}
-
-module "lambda_deployment_package_bucket" {
-  providers   = { aws = aws.audit }
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.11.0"
-  name        = "${var.bucket_base_name}-lambda-${local.account_id}"
-  versioning  = true
-  tags        = {}
-  kms_key_arn = var.kms_key_arn
-
-  lifecycle_rule = [
-    {
-      id      = "default"
-      enabled = true
-
-      abort_incomplete_multipart_upload = {
-        days_after_initiation = 7
-      }
-
-      expiration = {
-        expired_object_delete_marker = true
-      }
-
-      noncurrent_version_expiration = {
-        noncurrent_days = 7
-      }
-    }
-  ]
 }
 
 module "lambda_terraform_deployment_package" {
@@ -122,20 +16,12 @@ module "lambda_terraform_deployment_package" {
   artifacts_dir            = "${path.root}/package/terraformcloud"
 }
 
-#data "archive_file" "lambda_terraform_zip" {
-#  type        = "zip"
-#  source_dir  = "${path.module}/src/terraformcloud"
-#  output_path = "${path.module}/src/terraformcloud.zip"
-#}
-
 resource "aws_s3_object" "lambda_terraform_deployment_package" {
-  provider = aws.audit
-  bucket   = module.lambda_deployment_package_bucket.name
-  # key        = "terraformcloud.zip"
-  key        = "terraformcloud/${element(split("/", module.lambda_terraform_deployment_package.local_filename), length(split("/", module.lambda_terraform_deployment_package.local_filename)) - 1)}"
+  provider   = aws.audit
+  bucket     = module.lambda_deployment_package_bucket.name
+  key        = local.s3_object_keys.terraform
   kms_key_id = var.kms_key_arn
-  #  source     = data.archive_file.lambda_terraform_zip.output_path
-  source = module.lambda_terraform_deployment_package.local_filename
+  source     = module.lambda_terraform_deployment_package.local_filename
 }
 
 module "terraform_cloud_audit_logs_lambda" {
@@ -148,20 +34,17 @@ module "terraform_cloud_audit_logs_lambda" {
   create_policy          = false
   create_s3_dummy_object = false
   description            = "Lambda for gathering audit logs from Terraform Cloud and storing them in S3"
-  # filename               = data.archive_file.lambda_terraform_zip.output_path
-  # filename      = module.lambda_terraform_deployment_package.local_filename
-  handler       = "${local.audit_lambda_names.terraform}.handler"
-  kms_key_arn   = var.kms_key_arn
-  log_retention = 365
-  memory_size   = 512
-  runtime       = "python${var.python_version}"
-  s3_bucket     = "${var.bucket_base_name}-lambda-${local.account_id}"
-  # s3_key            = aws_s3_object.lambda_terraform_deployment_package.key
-  s3_key            = "terraformcloud/${element(split("/", module.lambda_terraform_deployment_package.local_filename), length(split("/", module.lambda_terraform_deployment_package.local_filename)) - 1)}"
-  s3_object_version = aws_s3_object.lambda_terraform_deployment_package.version_id
-  source_code_hash  = aws_s3_object.lambda_terraform_deployment_package.checksum_sha256
-  tags              = {}
-  timeout           = 600
+  handler                = "${local.audit_lambda_names.terraform}.handler"
+  kms_key_arn            = var.kms_key_arn
+  log_retention          = 365
+  memory_size            = 512
+  runtime                = "python${var.python_version}"
+  s3_bucket              = "${var.bucket_base_name}-lambda-${local.account_id}"
+  s3_key                 = local.s3_object_keys.terraform
+  s3_object_version      = aws_s3_object.lambda_terraform_deployment_package.version_id
+  source_code_hash       = aws_s3_object.lambda_terraform_deployment_package.checksum_sha256
+  tags                   = {}
+  timeout                = 600
 
   environment = {
     token_secret_name = local.environment.terraform_token_secret
@@ -169,6 +52,55 @@ module "terraform_cloud_audit_logs_lambda" {
     logs_url          = local.environment.terraform_api_url
     queue_url         = aws_sqs_queue.terraform_audit_log_queue.id
     file_prefix       = "terraform_logs/"
+  }
+}
+
+module "lambda_okta_deployment_package" {
+  providers                = { aws = aws.audit }
+  source                   = "terraform-aws-modules/lambda/aws"
+  version                  = "~> 7.2.5"
+  create_function          = false
+  recreate_missing_package = false
+  runtime                  = "python${var.python_version}"
+  source_path              = "${path.module}/src/okta"
+  artifacts_dir            = "${path.root}/package/okta"
+}
+
+resource "aws_s3_object" "lambda_okta_deployment_package" {
+  provider   = aws.audit
+  bucket     = module.lambda_deployment_package_bucket.name
+  key        = local.s3_object_keys.okta
+  kms_key_id = var.kms_key_arn
+  source     = module.lambda_okta_deployment_package.local_filename
+}
+
+module "okta_audit_logs_lambda" {
+  #checkov:skip=CKV_AWS_272:Code signing not used for now
+  providers = { aws = aws.audit }
+  #source                 = "schubergphilis/mcaf-lambda/aws"
+  #version                = "~> 1.2.1"
+  source                 = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=f-add-role-name-output" #TODO Pending https://github.com/schubergphilis/okta-aws-mcaf-lambda/pull/73
+  name                   = local.audit_lambda_names.okta
+  create_policy          = false
+  create_s3_dummy_object = false
+  description            = "Lambda for gathering audit logs from Okta and storing them in S3"
+  handler                = "${local.audit_lambda_names.okta}.handler"
+  kms_key_arn            = var.kms_key_arn
+  log_retention          = 365
+  memory_size            = 512
+  runtime                = "python${var.python_version}"
+  s3_bucket              = "${var.bucket_base_name}-lambda-${local.account_id}"
+  s3_key                 = local.s3_object_keys.okta
+  s3_object_version      = aws_s3_object.lambda_okta_deployment_package.version_id
+  source_code_hash       = aws_s3_object.lambda_okta_deployment_package.checksum_sha256
+  tags                   = {}
+  timeout                = 600
+
+  environment = {
+    file_prefix       = "okta_logs/"
+    log_level         = "info"
+    logs_bucket       = module.audit_logs_archive_bucket.name
+    token_secret_name = local.environment.okta_token_secret
   }
 }
 
@@ -186,20 +118,6 @@ module "terraform_cloud_audit_logs_lambda" {
 #  artifacts_dir            = "gitlab"
 #}
 #
-#module "lambda_okta_deployment_package" {
-#  providers                = { aws = aws.audit }
-#  source                   = "terraform-aws-modules/lambda/aws"
-#  version                  = "~> 6.4.0"
-#  create_function          = false
-#  recreate_missing_package = false
-#  runtime                  = "python${var.python_version}"
-#  s3_bucket                = module.lambda_deployment_package_bucket.name
-#  s3_object_storage_class  = "STANDARD"
-#  source_path              = "src/okta"
-#  store_on_s3              = true
-#  artifacts_dir            = "okta"
-#}
-
 # module "gitlab_audit_logs_lambda" {
 #   #checkov:skip=CKV_AWS_272:Code signing not used for now
 #   providers              = { aws = aws.audit }
@@ -230,33 +148,3 @@ module "terraform_cloud_audit_logs_lambda" {
 #     days_of_audit_logs = 1
 #   }
 # }
-
-#module "okta_audit_logs_lambda" {
-#  #checkov:skip=CKV_AWS_272:Code signing not used for now
-#  providers              = { aws = aws.audit }
-#  source                 = "schubergphilis/mcaf-lambda/aws"
-#  version                = "~> 1.1.0"
-#  name                   = local.audit_lambda_names.okta
-#  create_policy          = false
-#  create_s3_dummy_object = false
-#  description            = "Lambda for gathering audit logs from Okta and storing them in S3"
-#  filename               = module.lambda_okta_deployment_package.local_filename
-#  handler                = "${local.audit_lambda_names.okta}.handler"
-#  kms_key_arn            = var.kms_key_arn
-#  log_retention          = 365
-#  memory_size            = 512
-#  role_arn               = aws_iam_role.role_lambda_audit_logs["okta"].arn
-#  runtime                = "python${var.python_version}"
-#  s3_bucket              = module.lambda_deployment_package_bucket.name
-#  s3_key                 = module.lambda_okta_deployment_package.s3_object.key
-#  s3_object_version      = module.lambda_okta_deployment_package.s3_object.version_id
-#  tags                   = {}
-#  timeout                = 600
-#
-#  environment = {
-#    token_secret_name = local.environment.okta_token_secret
-#    logs_bucket       = module.audit_logs_archive_bucket.name
-#    log_level         = "info"
-#    file_prefix       = "okta_logs/"
-#  }
-#}

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ module "lambda_terraform_deployment_package" {
   version                  = "~> 7.2.5"
   create_function          = false
   recreate_missing_package = false
-  runtime                  = "python3.12"
+  runtime                  = "python${python_version}"
   s3_bucket                = module.lambda_deployment_package_bucket.name
   s3_object_storage_class  = "STANDARD"
   source_path              = "${path.module}/src/terraformcloud"
@@ -154,7 +154,7 @@ module "terraform_cloud_audit_logs_lambda" {
   kms_key_arn            = var.kms_key_arn
   log_retention          = 365
   memory_size            = 512
-  runtime                = "python3.12"
+  runtime                = "python${python_version}"
   s3_bucket              = "${var.bucket_base_name}-lambda-${local.account_id}"
   s3_key                 = aws_s3_object.lambda_terraform_deployment_package.key
   s3_object_version      = aws_s3_object.lambda_terraform_deployment_package.version_id
@@ -177,7 +177,7 @@ module "terraform_cloud_audit_logs_lambda" {
 #  version                  = "~> 6.4.0"
 #  create_function          = false
 #  recreate_missing_package = false
-#  runtime                  = "python3.12"
+#  runtime                  = "python${python_version}"
 #  s3_bucket                = module.lambda_deployment_package_bucket.name
 #  s3_object_storage_class  = "STANDARD"
 #  source_path              = "src/gitlab"
@@ -191,7 +191,7 @@ module "terraform_cloud_audit_logs_lambda" {
 #  version                  = "~> 6.4.0"
 #  create_function          = false
 #  recreate_missing_package = false
-#  runtime                  = "python3.12"
+#  runtime                  = "python${python_version}"
 #  s3_bucket                = module.lambda_deployment_package_bucket.name
 #  s3_object_storage_class  = "STANDARD"
 #  source_path              = "src/okta"
@@ -214,7 +214,7 @@ module "terraform_cloud_audit_logs_lambda" {
 #   log_retention          = 365
 #   memory_size            = 512
 #   role_arn               = aws_iam_role.role_lambda_audit_logs["gitlab"].arn
-#   runtime                = "python3.12"
+#   runtime                = "python${python_version}"
 #   s3_bucket              = module.lambda_deployment_package_bucket.name
 #   s3_key                 = module.lambda_gitlab_deployment_package.s3_object.key
 #   s3_object_version      = module.lambda_gitlab_deployment_package.s3_object.version_id
@@ -245,7 +245,7 @@ module "terraform_cloud_audit_logs_lambda" {
 #  log_retention          = 365
 #  memory_size            = 512
 #  role_arn               = aws_iam_role.role_lambda_audit_logs["okta"].arn
-#  runtime                = "python3.12"
+#  runtime                = "python${python_version}"
 #  s3_bucket              = module.lambda_deployment_package_bucket.name
 #  s3_key                 = module.lambda_okta_deployment_package.s3_object.key
 #  s3_object_version      = module.lambda_okta_deployment_package.s3_object.version_id

--- a/secrets.tf
+++ b/secrets.tf
@@ -22,14 +22,14 @@ resource "aws_secretsmanager_secret_version" "terraform_token_secret_version" {
   secret_string = var.terraform_token
 }
 
-#resource "aws_secretsmanager_secret" "okta_token_secret" {
-#  provider   = aws.audit
-#  name       = local.environment.okta_token_secret
-#  kms_key_id = var.kms_key_arn
-#}
-#
-#resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
-#  provider      = aws.audit
-#  secret_id     = aws_secretsmanager_secret.okta_token_secret.id
-#  secret_string = var.okta_token
-#}
+resource "aws_secretsmanager_secret" "okta_token_secret" {
+  provider   = aws.audit
+  name       = local.environment.okta_token_secret
+  kms_key_id = var.kms_key_arn
+}
+
+resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
+  provider      = aws.audit
+  secret_id     = aws_secretsmanager_secret.okta_token_secret.id
+  secret_string = var.okta_token
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -25,15 +25,15 @@ resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
   secret_string = var.okta_token
 }
 
-## Gitlab
-#resource "aws_secretsmanager_secret" "gitlab_token_secret" {
-#  provider   = aws.audit
-#  name       = local.environment.gitlab_token_secret
-#  kms_key_id = var.kms_key_arn
-#}
-#
-#resource "aws_secretsmanager_secret_version" "gitlab_token_secret_version" {
-#  provider      = aws.audit
-#  secret_id     = aws_secretsmanager_secret.gitlab_token_secret.id
-#  secret_string = var.gitlab_token
-#}
+# Gitlab
+resource "aws_secretsmanager_secret" "gitlab_token_secret" {
+  provider   = aws.audit
+  name       = local.environment.gitlab_token_secret
+  kms_key_id = var.kms_key_arn
+}
+
+resource "aws_secretsmanager_secret_version" "gitlab_token_secret_version" {
+  provider      = aws.audit
+  secret_id     = aws_secretsmanager_secret.gitlab_token_secret.id
+  secret_string = var.gitlab_token
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,15 +1,5 @@
-#resource "aws_secretsmanager_secret" "gitlab_token_secret" {
-#  provider   = aws.audit
-#  name       = local.environment.gitlab_token_secret
-#  kms_key_id = var.kms_key_arn
-#}
-#
-#resource "aws_secretsmanager_secret_version" "gitlab_token_secret_version" {
-#  provider      = aws.audit
-#  secret_id     = aws_secretsmanager_secret.gitlab_token_secret.id
-#  secret_string = var.gitlab_token
-#}
 
+# Terraform
 resource "aws_secretsmanager_secret" "terraform_token_secret" {
   provider   = aws.audit
   name       = local.environment.terraform_token_secret
@@ -22,6 +12,7 @@ resource "aws_secretsmanager_secret_version" "terraform_token_secret_version" {
   secret_string = var.terraform_token
 }
 
+# Okta
 resource "aws_secretsmanager_secret" "okta_token_secret" {
   provider   = aws.audit
   name       = local.environment.okta_token_secret
@@ -33,3 +24,16 @@ resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
   secret_id     = aws_secretsmanager_secret.okta_token_secret.id
   secret_string = var.okta_token
 }
+
+## Gitlab
+#resource "aws_secretsmanager_secret" "gitlab_token_secret" {
+#  provider   = aws.audit
+#  name       = local.environment.gitlab_token_secret
+#  kms_key_id = var.kms_key_arn
+#}
+#
+#resource "aws_secretsmanager_secret_version" "gitlab_token_secret_version" {
+#  provider      = aws.audit
+#  secret_id     = aws_secretsmanager_secret.gitlab_token_secret.id
+#  secret_string = var.gitlab_token
+#}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,6 +1,7 @@
 
 # Terraform
 resource "aws_secretsmanager_secret" "terraform_token_secret" {
+  #checkov:skip=CKV2_AWS_57: The secrets are managed outside AWS
   provider   = aws.audit
   name       = local.environment.terraform_token_secret
   kms_key_id = var.kms_key_arn
@@ -14,6 +15,7 @@ resource "aws_secretsmanager_secret_version" "terraform_token_secret_version" {
 
 # Okta
 resource "aws_secretsmanager_secret" "okta_token_secret" {
+  #checkov:skip=CKV2_AWS_57: The secrets are managed outside AWS
   provider   = aws.audit
   name       = local.environment.okta_token_secret
   kms_key_id = var.kms_key_arn
@@ -27,6 +29,7 @@ resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
 
 # Gitlab
 resource "aws_secretsmanager_secret" "gitlab_token_secret" {
+  #checkov:skip=CKV2_AWS_57: The secrets are managed outside AWS
   provider   = aws.audit
   name       = local.environment.gitlab_token_secret
   kms_key_id = var.kms_key_arn

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,35 @@
+#resource "aws_secretsmanager_secret" "gitlab_token_secret" {
+#  provider   = aws.audit
+#  name       = local.environment.gitlab_token_secret
+#  kms_key_id = var.kms_key_arn
+#}
+#
+#resource "aws_secretsmanager_secret_version" "gitlab_token_secret_version" {
+#  provider      = aws.audit
+#  secret_id     = aws_secretsmanager_secret.gitlab_token_secret.id
+#  secret_string = var.gitlab_token
+#}
+
+resource "aws_secretsmanager_secret" "terraform_token_secret" {
+  provider   = aws.audit
+  name       = local.environment.terraform_token_secret
+  kms_key_id = var.kms_key_arn
+}
+
+resource "aws_secretsmanager_secret_version" "terraform_token_secret_version" {
+  provider      = aws.audit
+  secret_id     = aws_secretsmanager_secret.terraform_token_secret.id
+  secret_string = var.terraform_token
+}
+
+#resource "aws_secretsmanager_secret" "okta_token_secret" {
+#  provider   = aws.audit
+#  name       = local.environment.okta_token_secret
+#  kms_key_id = var.kms_key_arn
+#}
+#
+#resource "aws_secretsmanager_secret_version" "okta_token_secret_version" {
+#  provider      = aws.audit
+#  secret_id     = aws_secretsmanager_secret.okta_token_secret.id
+#  secret_string = var.okta_token
+#}

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,3 +1,4 @@
+# SQS is only used for terraform audit logs
 resource "aws_lambda_event_source_mapping" "terraform_audit_sqs_trigger" {
   provider         = aws.audit
   batch_size       = 1

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,0 +1,29 @@
+resource "aws_lambda_event_source_mapping" "terraform_audit_sqs_trigger" {
+  provider         = aws.audit
+  batch_size       = 1
+  event_source_arn = aws_sqs_queue.terraform_audit_log_queue.arn
+  function_name    = module.terraform_cloud_audit_logs_lambda.arn
+}
+
+resource "aws_sqs_queue" "terraform_audit_log_dlq" {
+  provider                  = aws.audit
+  name                      = "terraform-audit-log-dlq"
+  kms_master_key_id         = var.kms_key_arn
+  message_retention_seconds = 691200
+}
+
+resource "aws_sqs_queue" "terraform_audit_log_queue" {
+  provider                   = aws.audit
+  name                       = "terraform-audit-log-queue"
+  delay_seconds              = 90
+  kms_master_key_id          = var.kms_key_arn
+  max_message_size           = 2048
+  message_retention_seconds  = 345600
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 1200
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.terraform_audit_log_dlq.arn
+    maxReceiveCount     = 4
+  })
+}

--- a/src/gitlab/gitlab_audit_logs.py
+++ b/src/gitlab/gitlab_audit_logs.py
@@ -1,0 +1,144 @@
+import boto3
+import compress_json
+import datetime
+import logging
+import os
+import requests
+
+logger = logging.getLogger()
+logger.setLevel(logging.os.environ["log_level"].upper())
+
+def fetch_token(token_secret_name):
+    secrets_client = boto3.client("secretsmanager")
+    secret_response = secrets_client.get_secret_value(
+        SecretId=token_secret_name
+    )
+
+    return secret_response["SecretString"]
+
+
+def get_group_ids(initial_url, headers):
+    url = f'{initial_url}/groups'
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        groups = response.json()
+        group_ids = [group['id'] for group in groups]
+        return group_ids
+    else:
+        logging.error(f'Error getting group IDs: {response.status_code}')
+        return []
+
+
+def get_project_ids(initial_url, headers, group_id, project_ids):
+    url = f'{initial_url}/groups/{group_id}/projects'
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        projects = response.json()
+        list_of_group_project_ids = [project['id'] for project in projects]
+        project_ids.update(list_of_group_project_ids)
+        return project_ids
+    else:
+        logging.error(f'Error getting project IDs: {response.status_code}')
+        return []
+
+
+def get_audit_events(url, headers, data, id, type="group"):
+    complete_url = f'{url}/{type}/{id}/audit_events'
+    response = requests.get(
+        complete_url,
+        headers=headers,
+        data=data
+    )
+    if response.status_code == 200:
+        return response.json()
+    else:
+        logging.error(f'Error getting audit events for {type} {id}: {response.status_code}')
+        return []
+
+
+def upload_to_s3(file_name, bucket, audit_data, type="groups"):
+    file_path = "/tmp/" + file_name
+    compress_json.dump(audit_data, file_path)
+    s3 = boto3.resource("s3")
+    file = f'gitlab_{type}_audit_log/{file_name}'
+    logging.info(f'Dumping Gitlab {type} audit data')
+    s3.meta.client.upload_file(
+        file_path,
+        bucket,
+        file
+    )
+
+
+# Main function to get and print audit events for all groups and projects
+def handler(event, context):
+    project_ids = set()
+    all_group_audit_events = []
+    all_project_audit_events = []
+    token_secret_name = os.environ["token_secret_name"]
+    token = fetch_token(token_secret_name)
+    bucket = os.environ["logs_bucket"]
+    initial_url = os.environ["logs_url"]
+
+    headers = {
+        'PRIVATE-TOKEN': token
+    }
+    today = datetime.date.today()
+    created = today - datetime.timedelta(days=int(os.environ["days_of_audit_logs"]))
+    created_after = created.strftime("%Y-%m-%dT%H:%M:%SZ")
+    created_before = today.strftime("%Y-%m-%dT%H:%M:%SZ")
+    data = {
+        "created_after": created_after,
+        "created_before": created_before
+    }
+    logging.info(f'Logging that will be collected will be between {created_after} and {created_before}')
+    group_ids = get_group_ids(initial_url, headers)
+    logging.debug(f'List of group ids {group_ids}')
+
+    for group_id in group_ids:
+        group_audit_events = get_audit_events(
+            url=initial_url,
+            headers=headers,
+            data=data,
+            id=group_id,
+            type="groups"
+        )
+        logging.debug(f'Audit events for group {group_id}: {group_audit_events}')
+        all_group_audit_events += group_audit_events
+        project_ids = get_project_ids(
+            initial_url,
+            headers,
+            group_id,
+            project_ids
+        )
+    logging.debug(f'List of project ids {project_ids}')
+
+    for project_id in project_ids:
+        project_audit_events = get_audit_events(
+            url=initial_url,
+            headers=headers,
+            data=data,
+            id=project_id,
+            type="projects"
+        )
+        logging.debug(f'Audit events for project {project_id}: {project_audit_events}')
+        all_project_audit_events += project_audit_events
+
+    file_name = (
+        created.strftime("%Y%m%d") + ".json.gz"
+    )
+
+    upload_to_s3(
+        file_name=file_name,
+        bucket=bucket,
+        audit_data=all_group_audit_events,
+        type="groups"
+    )
+
+    upload_to_s3(
+        file_name=file_name,
+        bucket=bucket,
+        audit_data=all_project_audit_events,
+        type="projects"
+    )
+
+    return "File stored"

--- a/src/gitlab/requirements.txt
+++ b/src/gitlab/requirements.txt
@@ -1,0 +1,2 @@
+compress_json==1.0.4
+requests==2.25.1

--- a/src/okta/okta_audit_logs.py
+++ b/src/okta/okta_audit_logs.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timezone, timedelta
+import requests
+import pandas as pd
+import json
+import os
+import boto3
+import logging
+import gzip
+import shutil
+
+logger = logging.getLogger()
+logger.setLevel(logging.os.environ["log_level"].upper())
+
+def fetch_token(token_secret_name):
+    secrets_client = boto3.client("secretsmanager")
+    secret_response = secrets_client.get_secret_value(
+        SecretId=token_secret_name
+    )
+
+    return secret_response["SecretString"]
+
+def handler(event, context):
+    # # Create a UTC datetime object
+    # utc_datetime = datetime.now(timezone.utc)
+    # twenty_four_hours_ago = utc_datetime - timedelta(hours=24)
+
+    # # Convert UTC datetime to ISO-8601 format
+    # iso8601_format = twenty_four_hours_ago.isoformat("T", "milliseconds")
+
+    # # Okta url date and time
+    # okta_date_time = iso8601_format.replace("+00:00", "Z")
+
+    # base_url = "https://cbh.okta.com/api/v1/logs?since="
+    # url = base_url + okta_date_time
+
+    # Current date in ISO format (assuming today is 2023-12-11)
+    today = datetime.now()
+
+    # Calculate yesterday's date
+    yesterday = today - timedelta(days=1)
+
+    # Create start_time and end_time variables for yesterday
+    start_time = yesterday.strftime("%Y-%m-%dT00:00:00.000Z")
+    end_time = yesterday.strftime("%Y-%m-%dT23:59:59.999Z")
+
+    # Construct the URL
+    url = f"https://cbh.okta.com/api/v1/logs?since={start_time}&until={end_time}&limit=1000"
+
+    token_secret_name = os.environ["token_secret_name"]
+    token = fetch_token(token_secret_name)
+
+    # Replace with your Okta API token or authentication method
+    headers = {
+        "Authorization": "SSWS " + token
+    }
+
+    # Make the GET request
+    response = requests.get(url, headers=headers)
+
+    # Check if the request was successful (status code 200)
+    if response.status_code == 200:
+        # Parse the JSON response
+        log_data = response.json()
+        # Process the log data as needed
+        print("Log data retrieved successfully.")
+        print(log_data)
+        filename = '/tmp/log_data.json'
+
+        # Write the log_data to the file
+        with open(filename, 'w') as file:
+            json.dump(log_data, file, indent=4)  # You can use indent to make the JSON data more readable
+
+        print(f"Log data has been written to {filename}")
+    else:
+        logging.error(f"Error: HTTP status code {response.status_code}")
+        logging.error(response.text)
+
+    df = pd.read_json('/tmp/log_data.json')
+    df.to_csv('/tmp/log_file.csv')
+
+    # Initialize the S3 client
+    s3 = boto3.client('s3')
+    s3_bucket_name = os.environ["logs_bucket"]
+
+    original_filename = '/tmp/log_file.csv'
+
+    # Path for the resulting .gz file
+    gz_file_name = '/tmp/log_file.csv.gz'
+
+    # Compressing the CSV file into a .gz file
+    with open(original_filename, 'rb') as f_in:
+        with gzip.open(gz_file_name, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+
+    # Get the current date and time
+    current_datetime = datetime.now(timezone.utc)
+
+    # Format the date and time (e.g., YYYYMMDD_HHMMSS)
+    datetime_stamp = current_datetime.strftime("%Y%m%d_%H%M%S")
+
+    # New filename with date-time stamp
+    new_filename = f"{os.path.splitext(gz_file_name)[0]}_{datetime_stamp}.csv.gz"
+
+    # Rename the file
+    os.rename(gz_file_name, new_filename)
+    log_file_prefix = os.environ["file_prefix"]
+
+    # Specify the S3 object key (file name in the bucket)
+    s3_object_key = log_file_prefix + new_filename.replace("/tmp/", "")  # Customize the path as needed
+
+    # Upload the file to the S3 bucket
+    s3.upload_file(new_filename, s3_bucket_name, s3_object_key)
+
+    # Clean up: Remove the local file if needed
+    os.remove(new_filename)
+    os.remove('/tmp/log_data.json')
+
+    logging.error
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    (f"Log data has been saved to '{new_filename}' and uploaded to S3 bucket '{s3_bucket_name}' with object key '{s3_object_key}'.")

--- a/src/okta/requirements.txt
+++ b/src/okta/requirements.txt
@@ -1,0 +1,5 @@
+requests==2.25.1
+pandas==2.0.3
+python-dateutil==2.8.2
+numpy==1.26.2
+pytz==2023.3

--- a/src/okta/requirements.txt
+++ b/src/okta/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.25.1
 pandas==2.0.3
 python-dateutil==2.8.2
-numpy==1.26.2
+numpy==1.24.4
 pytz==2023.3

--- a/src/terraformcloud/requirements.txt
+++ b/src/terraformcloud/requirements.txt
@@ -1,0 +1,2 @@
+compress_json==1.0.4
+requests==2.25.1

--- a/src/terraformcloud/terraform_cloud_audit_logs.py
+++ b/src/terraformcloud/terraform_cloud_audit_logs.py
@@ -1,0 +1,163 @@
+import boto3
+import compress_json
+import datetime
+import json
+import os
+import requests
+import time
+import random
+
+
+def uniqueid():
+    seed = random.getrandbits(32)
+
+    while True:
+        yield seed
+        seed += 1
+
+
+def fetch_token(token_secret_name):
+    secrets_client = boto3.client("secretsmanager")
+    secret_response = secrets_client.get_secret_value(
+        SecretId=token_secret_name
+    )
+
+    return secret_response["SecretString"]
+
+
+def handler(event, context):
+
+    token_secret_name = os.environ["token_secret_name"]
+    token = fetch_token(token_secret_name)
+
+    bucket = os.environ["logs_bucket"]
+    initial_url = os.environ["logs_url"]
+    queue_url = os.environ["queue_url"]
+    log_file_prefix = os.environ["file_prefix"]
+
+    request_headers = {
+        "Content-Type": "application/json",
+        "Authorization": 'Bearer %s' % token
+    }
+
+    url = initial_url
+    created = datetime.date.today() - datetime.timedelta(days=1)
+    params = {}
+    log_date = created.strftime("%Y-%m-%d")
+    page = 1
+    total_pages = 1
+
+    unique_sequence = uniqueid()
+
+    sqs = boto3.client("sqs")
+
+    # Lambda is triggered from cloudwatch events. We should start the process
+    # using initial_url
+    if "source" in event and event["source"] == "aws.events":
+
+        # initial message to begin everything
+        sqs.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps({
+                "log_date": log_date,
+                "page": page,
+                "total_pages": total_pages,
+                "operation": "extract_init"
+            })
+        )
+
+        return "Initial message sent"
+
+    elif "Records" in event:
+
+        message = event["Records"][0]
+        body = json.loads(message["body"])
+        log_date = body["log_date"]
+        page = body["page"]
+        total_pages = body["total_pages"]
+        operation = body["operation"]
+
+        if operation == "extract_init" or operation == "extract_continue":
+
+            # this call is only to fetch pagination and setup
+            # extraction in parallel processes
+            if operation == "extract_init":
+                params = {"since": log_date}
+                response = requests.get(
+                    url,
+                    headers=request_headers,
+                    params=params
+                )
+                data = response.json()
+                pagination = data["pagination"]
+                total_pages = pagination["total_pages"]
+
+            sqs_pages = []
+            index = 0
+
+            for index in range(9):
+                if (index + page <= total_pages):
+                    # we will process these pages individually
+                    sqs_pages.append({
+                        "Id": str(next(unique_sequence)),
+                        "MessageBody": json.dumps({
+                            "page": index + page,
+                            "total_pages": total_pages,
+                            "operation": "extract",
+                            "log_date": log_date
+                        })
+                    })
+
+            # batch only support 10 messages at a time so we will
+            # setup next 10 pages in a separate call. This also makes
+            # sure that each process is short and does one thing properly
+            if index + page < total_pages:
+                sqs_pages.append({
+                        "Id": str(next(unique_sequence)),
+                        "MessageBody": json.dumps({
+                            "page": index + page + 1,
+                            "total_pages": total_pages,
+                            "operation": "extract_continue",
+                            "log_date": log_date
+                        })
+                    })
+
+            if len(sqs_pages) > 0:
+                return sqs.send_message_batch(
+                    QueueUrl=queue_url,
+                    Entries=sqs_pages
+                )
+
+            return "Nothing to continue"
+
+    else:
+        return "Invalid event source, nothing to do here"
+
+    params = {"since": log_date, "page[number]": page}
+    response = requests.get(url, headers=request_headers, params=params)
+    data = response.json()
+    audit_data = data["data"]
+
+    if len(audit_data) > 0:
+
+        print("Dumping", audit_data)
+
+        # <log date>:<extract date/time>:<page number>
+        file_name = (
+            log_date + ":" +
+            created.strftime("%Y%m%d-%H%M%S") + ":" +
+            str(page) + ".json.gz"
+        )
+        file_path = "/tmp/" + file_name
+        compress_json.dump(audit_data, file_path)
+
+        s3 = boto3.resource("s3")
+        s3.meta.client.upload_file(
+            file_path,
+            bucket,
+            log_file_prefix + created.strftime("%Y%m%d") + "/" + file_name
+        )
+
+        return "File stored"
+
+    return "Nothing to store"

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,14 @@ variable "okta_token" {
   description = "The Okta token used to authenticate with the Okta API"
 }
 
+variable "python_version" {
+  type        = string
+  default     = "3.12"
+  description = "The version of Python to use in the Lambda functions"
+}
+
 variable "terraform_token" {
   type        = string
   description = "The Terraform Cloud Organisation token used to authenticate with the Terraform Cloud API"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "gitlab_token" {
+  type        = string
+  description = "The GitLab token used to authenticate with the GitLab API"
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key used to encrypt the resources"
+}
+
+variable "okta_token" {
+  type        = string
+  description = "The Okta token used to authenticate with the Okta API"
+}
+
+variable "terraform_token" {
+  type        = string
+  description = "The Terraform Cloud token used to authenticate with the Terraform Cloud API"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,5 +33,5 @@ variable "okta_token" {
 
 variable "terraform_token" {
   type        = string
-  description = "The Terraform Cloud token used to authenticate with the Terraform Cloud API"
+  description = "The Terraform Cloud Organisation token used to authenticate with the Terraform Cloud API"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,4 +41,3 @@ variable "terraform_token" {
   type        = string
   description = "The Terraform Cloud Organisation token used to authenticate with the Terraform Cloud API"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,15 @@ variable "terraform_token" {
   type        = string
   description = "The Terraform Cloud token used to authenticate with the Terraform Cloud API"
 }
+
+variable "object_locking" {
+  type = object({
+    mode  = string
+    years = number
+  })
+  default = {
+    mode  = "GOVERNANCE"
+    years = 1
+  }
+  description = "The object locking configuration for the S3 buckets"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "bucket_base_name" {
+  type        = string
+  default     = "audit-logs"
+  description = "The base name for the S3 buckets"
+}
+
 variable "gitlab_token" {
   type        = string
   description = "The GitLab token used to authenticate with the GitLab API"
@@ -6,16 +12,6 @@ variable "gitlab_token" {
 variable "kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key used to encrypt the resources"
-}
-
-variable "okta_token" {
-  type        = string
-  description = "The Okta token used to authenticate with the Okta API"
-}
-
-variable "terraform_token" {
-  type        = string
-  description = "The Terraform Cloud token used to authenticate with the Terraform Cloud API"
 }
 
 variable "object_locking" {
@@ -28,4 +24,14 @@ variable "object_locking" {
     years = 1
   }
   description = "The object locking configuration for the S3 buckets"
+}
+
+variable "okta_token" {
+  type        = string
+  description = "The Okta token used to authenticate with the Okta API"
+}
+
+variable "terraform_token" {
+  type        = string
+  description = "The Terraform Cloud token used to authenticate with the Terraform Cloud API"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 4.40.0"
+      configuration_aliases = [aws.audit]
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,4 +6,5 @@ terraform {
       configuration_aliases = [aws.audit]
     }
   }
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
- **Initial commit of terraform audit lambda**
- **Make object locking configurable set change default to GOVERNANCE**
- **Parameterise bucket name and add provider for s3_object**
- **Fix dependency logging bucket and fix role_name iso function name**
- **Add KMS key update to README**
- **Make python version configurable and lower python version because of version available in cloud runners of TF**
- **Have only buidling done with deployment_package module, do uploading from here and also configure lambda**
- **Enable Okta audit logs and lower numpy to 1.24.4 (okta requirements.txt) due to python version**
- **Refactor order of resources, grouping by logging source and adding comments**
- **Adds required version for TF**
- **Enable Gitlab audit logs**
- **Fix checkov findings and remove tfsec mentions as we don't use that anymore**
- **Temporarily add workflows to be later added via sync**
- **Use Lambda from registry**
